### PR TITLE
update(api): habilitado 0.0.0.0:5002 para acceso desde red local

### DIFF
--- a/FeeLink.Api/Program.cs
+++ b/FeeLink.Api/Program.cs
@@ -1,4 +1,4 @@
-using FeeLink.Infrastructure.Common.DependencyInjection;
+﻿using FeeLink.Infrastructure.Common.DependencyInjection;
 using FeeLink.Api.Common.DependencyInjection;
 using FeeLink.Api.Common.HttpConfigurations;
 using FeeLink.Api.WebSockets;

--- a/FeeLink.Api/Properties/launchSettings.json
+++ b/FeeLink.Api/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5002",
+      "applicationUrl": "http://0.0.0.0:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -14,7 +14,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "https://localhost:7117;http://localhost:5002",
+      "applicationUrl": "https://0.0.0.0:7117;http://0.0.0.0:5002",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/FeeLink.Api/appsettings.Development.json
+++ b/FeeLink.Api/appsettings.Development.json
@@ -35,7 +35,10 @@
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:5173",
-      "http://localshost:3000"
+      "http://localshost:3000",
+      "http://localhost:5002",
+      "http://127.0.0.1:5002",
+      "http://192.168.1.11:5002"
     ]
   }
 }

--- a/FeeLink.Api/appsettings.json
+++ b/FeeLink.Api/appsettings.json
@@ -35,7 +35,11 @@
   "Cors": {
     "AllowedOrigins": [
       "http://localhost:5173",
-      "http://localshost:3000"
+      "http://localshost:3000",
+      "http://localhost:5002",
+      "http://127.0.0.1:5002",
+      "http://192.168.1.11:5002",
+      "http://10.0.2.2:5002"
     ]
   }
 }


### PR DESCRIPTION
1. Se actualizó la configuración del backend para escuchar en 0.0.0.0 en lugar de localhost,
 lo cual permite conexiones desde dispositivos externos como celulares y emuladores.
2. También se ajustaron los CORS para permitir estos orígenes.
